### PR TITLE
Fix linter error: type check missing

### DIFF
--- a/src/elements/Divider/index.js
+++ b/src/elements/Divider/index.js
@@ -38,7 +38,8 @@ Divider.propTypes = {
   fitted: PropTypes.bool,
   hidden: PropTypes.bool,
   section: PropTypes.bool,
-  clearing: PropTypes.bool
+  clearing: PropTypes.bool,
+  inverted: PropTypes.bool
 }
 
 export default Divider


### PR DESCRIPTION
`elements/Divider`